### PR TITLE
fix: use broader type for RouteStop station

### DIFF
--- a/public/swagger.json
+++ b/public/swagger.json
@@ -168,6 +168,24 @@
         "type": "object",
         "additionalProperties": true
       },
+      "HafasCoordinates": {
+        "properties": {
+          "lat": {
+            "type": "number",
+            "format": "double"
+          },
+          "lng": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "lat",
+          "lng"
+        ],
+        "type": "object",
+        "additionalProperties": true
+      },
       "Pick_GroupedStopPlace.name-or-evaNumber-or-ril100_": {
         "properties": {
           "name": {
@@ -187,8 +205,34 @@
         "type": "object",
         "description": "From T, pick a set of properties whose keys are in the union K"
       },
-      "MinimalStopPlace": {
-        "$ref": "#/components/schemas/Pick_GroupedStopPlace.name-or-evaNumber-or-ril100_"
+      "HafasStation": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "evaNumber": {
+            "type": "string"
+          },
+          "ril100": {
+            "type": "string"
+          },
+          "products": {
+            "items": {
+              "$ref": "#/components/schemas/ParsedProduct"
+            },
+            "type": "array"
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/HafasCoordinates"
+          }
+        },
+        "required": [
+          "name",
+          "evaNumber",
+          "coordinates"
+        ],
+        "type": "object",
+        "additionalProperties": true
       },
       "AuslastungsValue": {
         "description": "1: Gering\n2: Hoch\n3: Sehr Hoch\n4: Ausgebucht",
@@ -438,7 +482,7 @@
             "$ref": "#/components/schemas/CommonStopInfo"
           },
           "station": {
-            "$ref": "#/components/schemas/MinimalStopPlace"
+            "$ref": "#/components/schemas/HafasStation"
           },
           "auslastung": {
             "$ref": "#/components/schemas/RouteAuslastung"
@@ -1067,53 +1111,6 @@
           "journeyID",
           "originSchedule",
           "type"
-        ],
-        "type": "object",
-        "additionalProperties": true
-      },
-      "HafasCoordinates": {
-        "properties": {
-          "lat": {
-            "type": "number",
-            "format": "double"
-          },
-          "lng": {
-            "type": "number",
-            "format": "double"
-          }
-        },
-        "required": [
-          "lat",
-          "lng"
-        ],
-        "type": "object",
-        "additionalProperties": true
-      },
-      "HafasStation": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "evaNumber": {
-            "type": "string"
-          },
-          "ril100": {
-            "type": "string"
-          },
-          "products": {
-            "items": {
-              "$ref": "#/components/schemas/ParsedProduct"
-            },
-            "type": "array"
-          },
-          "coordinates": {
-            "$ref": "#/components/schemas/HafasCoordinates"
-          }
-        },
-        "required": [
-          "name",
-          "evaNumber",
-          "coordinates"
         ],
         "type": "object",
         "additionalProperties": true
@@ -1855,6 +1852,9 @@
             "$ref": "#/components/schemas/SecLKISS"
           }
         ]
+      },
+      "MinimalStopPlace": {
+        "$ref": "#/components/schemas/Pick_GroupedStopPlace.name-or-evaNumber-or-ril100_"
       },
       "RouteTarifFare": {
         "properties": {

--- a/src/server/API/routes.ts
+++ b/src/server/API/routes.ts
@@ -88,14 +88,30 @@ const models: TsoaRoute.Models = {
         "additionalProperties": true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "HafasCoordinates": {
+        "dataType": "refObject",
+        "properties": {
+            "lat": {"dataType":"double","required":true},
+            "lng": {"dataType":"double","required":true},
+        },
+        "additionalProperties": true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Pick_GroupedStopPlace.name-or-evaNumber-or-ril100_": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"string","required":true},"evaNumber":{"dataType":"string","required":true},"ril100":{"dataType":"string"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "MinimalStopPlace": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_GroupedStopPlace.name-or-evaNumber-or-ril100_","validators":{}},
+    "HafasStation": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "evaNumber": {"dataType":"string","required":true},
+            "ril100": {"dataType":"string"},
+            "products": {"dataType":"array","array":{"dataType":"refAlias","ref":"ParsedProduct"}},
+            "coordinates": {"ref":"HafasCoordinates","required":true},
+        },
+        "additionalProperties": true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "AuslastungsValue": {
@@ -209,7 +225,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "arrival": {"ref":"CommonStopInfo"},
             "departure": {"ref":"CommonStopInfo"},
-            "station": {"ref":"MinimalStopPlace","required":true},
+            "station": {"ref":"HafasStation","required":true},
             "auslastung": {"ref":"RouteAuslastung"},
             "messages": {"dataType":"array","array":{"dataType":"refObject","ref":"RemL"}},
             "additional": {"dataType":"boolean"},
@@ -415,27 +431,6 @@ const models: TsoaRoute.Models = {
             "journeyID": {"dataType":"string","required":true},
             "originSchedule": {"ref":"StopPlaceEmbedded","required":true},
             "type": {"ref":"JourneyType","required":true},
-        },
-        "additionalProperties": true,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "HafasCoordinates": {
-        "dataType": "refObject",
-        "properties": {
-            "lat": {"dataType":"double","required":true},
-            "lng": {"dataType":"double","required":true},
-        },
-        "additionalProperties": true,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "HafasStation": {
-        "dataType": "refObject",
-        "properties": {
-            "name": {"dataType":"string","required":true},
-            "evaNumber": {"dataType":"string","required":true},
-            "ril100": {"dataType":"string"},
-            "products": {"dataType":"array","array":{"dataType":"refAlias","ref":"ParsedProduct"}},
-            "coordinates": {"ref":"HafasCoordinates","required":true},
         },
         "additionalProperties": true,
     },
@@ -697,6 +692,11 @@ const models: TsoaRoute.Models = {
     "SecL": {
         "dataType": "refAlias",
         "type": {"dataType":"union","subSchemas":[{"ref":"SecLJNY"},{"ref":"SecLWALK"},{"ref":"SecLKISS"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MinimalStopPlace": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_GroupedStopPlace.name-or-evaNumber-or-ril100_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "RouteTarifFare": {

--- a/src/types/routing.ts
+++ b/src/types/routing.ts
@@ -13,7 +13,7 @@ import type { TransportPublicDestinationPortionWorking } from '@/external/genera
 export interface RouteStop {
   arrival?: CommonStopInfo;
   departure?: CommonStopInfo;
-  station: MinimalStopPlace;
+  station: HafasStation;
   auslastung?: RouteAuslastung;
   messages?: RemL[];
   additional?: boolean;


### PR DESCRIPTION
this pull request updates the type for the `RouteStop` `station` to use `HafasStation` instead of `MinimalStopPlace`, to match what the API returns in [`src/server/HAFAS/helper/parseStop.ts:22`](https://github.com/marudor/bahn.expert/blob/cf9c82121941aa45092028ec431f4c5528f2c862/src/server/HAFAS/helper/parseStop.ts#L22).

this wasn't caught by TypeScript as `HafasStation` fulfills `MinimalStopPlace`, this irritates some OpenAPI generated validators however.