### PR TITLE
feat: replacedBy and replacementFor

### DIFF
--- a/src/client/Common/Components/Details/ReplacedBy.tsx
+++ b/src/client/Common/Components/Details/ReplacedBy.tsx
@@ -1,0 +1,47 @@
+import { TransportName } from '@/client/Common/Components/Details/TransportName';
+import type { FC } from 'react';
+import type { TransportPublicDestinationOriginJourney } from '@/external/generated/risJourneys';
+
+interface Props {
+  startsBeingReplacedBy?: TransportPublicDestinationOriginJourney[];
+  stopsBeingReplacedBy?: TransportPublicDestinationOriginJourney[];
+  stopEva: string;
+}
+
+export const ReplacedBy: FC<Props> = ({
+  startsBeingReplacedBy,
+  stopsBeingReplacedBy,
+  stopEva,
+}) => {
+  const starts = startsBeingReplacedBy?.map((j) => (
+    <span key={j.journeyID}>
+      Ersetzt durch <TransportName transport={j} />
+    </span>
+  ));
+  const stops = stopsBeingReplacedBy?.map((j) => {
+    if (
+      stopEva ===
+      (j.differingDestination?.evaNumber || j.destination?.evaNumber)
+    ) {
+      return (
+        <span key={j.journeyID}>
+          <TransportName transport={j} /> endet in{' '}
+          {j.differingDestination?.name || j.destination?.name}
+        </span>
+      );
+    }
+    return (
+      <span key={j.journeyID}>
+        <TransportName transport={j} /> fährt weiter nach{' '}
+        {j.differingDestination?.name || j.destination?.name}
+      </span>
+    );
+  });
+
+  return (
+    <>
+      {starts}
+      {stops}
+    </>
+  );
+};

--- a/src/client/Common/Components/Details/ReplacedBySummary.tsx
+++ b/src/client/Common/Components/Details/ReplacedBySummary.tsx
@@ -1,0 +1,49 @@
+import { styled } from '@mui/material';
+import { TransportName } from '@/client/Common/Components/Details/TransportName';
+import type { FC } from 'react';
+import type { RouteStop } from '@/types/routing';
+
+const Container = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  margin: '0.65em',
+  padding: '0.65em',
+  border: `1px ${theme.vars.palette.text.primary} solid`,
+}));
+
+interface Props {
+  stops: RouteStop[];
+}
+
+export const ReplacedBySummary: FC<Props> = ({ stops }) => {
+  const travelsWithEntries = stops.flatMap(
+    (s) =>
+      s.joinsWith?.map((t) => ({
+        ...t,
+        stop: s,
+        stopsBeingReplacedBy: stops.find(
+          (s) =>
+            s.stopsBeingReplacedBy?.find((r) => r.journeyID === t.journeyID) !==
+            undefined,
+        ),
+      })) || [],
+  );
+
+  if (!travelsWithEntries.length) {
+    return null;
+  }
+
+  return (
+    <Container>
+      {travelsWithEntries.map((t) => (
+        <span key={t.journeyID}>
+          Wird von {t.stop.station.name} bis{' '}
+          {t.stopsBeingReplacedBy?.station.name ||
+            t.differingDestination?.name ||
+            t.destination.name}{' '}
+          durch <TransportName transport={t} /> ersetzt
+        </span>
+      ))}
+    </Container>
+  );
+};

--- a/src/client/Common/Components/Details/ReplacementFor.tsx
+++ b/src/client/Common/Components/Details/ReplacementFor.tsx
@@ -1,0 +1,47 @@
+import { TransportName } from '@/client/Common/Components/Details/TransportName';
+import type { FC } from 'react';
+import type { TransportPublicDestinationOriginJourney } from '@/external/generated/risJourneys';
+
+interface Props {
+  startsReplacing?: TransportPublicDestinationOriginJourney[];
+  stopsReplacing?: TransportPublicDestinationOriginJourney[];
+  stopEva: string;
+}
+
+export const ReplacementFor: FC<Props> = ({
+  startsReplacing,
+  stopsReplacing,
+  stopEva,
+}) => {
+  const starts = startsReplacing?.map((j) => (
+    <span key={j.journeyID}>
+      Ersatz für <TransportName transport={j} />
+    </span>
+  ));
+  const stops = stopsReplacing?.map((j) => {
+    if (
+      stopEva ===
+      (j.differingDestination?.evaNumber || j.destination?.evaNumber)
+    ) {
+      return (
+        <span key={j.journeyID}>
+          <TransportName transport={j} /> endet in{' '}
+          {j.differingDestination?.name || j.destination?.name}
+        </span>
+      );
+    }
+    return (
+      <span key={j.journeyID}>
+        <TransportName transport={j} /> fährt weiter nach{' '}
+        {j.differingDestination?.name || j.destination?.name}
+      </span>
+    );
+  });
+
+  return (
+    <>
+      {starts}
+      {stops}
+    </>
+  );
+};

--- a/src/client/Common/Components/Details/ReplacementForSummary.tsx
+++ b/src/client/Common/Components/Details/ReplacementForSummary.tsx
@@ -1,0 +1,49 @@
+import { styled } from '@mui/material';
+import { TransportName } from '@/client/Common/Components/Details/TransportName';
+import type { FC } from 'react';
+import type { RouteStop } from '@/types/routing';
+
+const Container = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  margin: '0.65em',
+  padding: '0.65em',
+  border: `1px ${theme.vars.palette.text.primary} solid`,
+}));
+
+interface Props {
+  stops: RouteStop[];
+}
+
+export const ReplacementForSummary: FC<Props> = ({ stops }) => {
+  const replacementForEntries = stops.flatMap(
+    (s) =>
+      s.startsReplacing?.map((t) => ({
+        ...t,
+        stop: s,
+        stopsReplacing: stops.find(
+          (s) =>
+            s.stopsReplacing?.find((r) => r.journeyID === t.journeyID) !==
+            undefined,
+        ),
+      })) || [],
+  );
+
+  if (!replacementForEntries.length) {
+    return null;
+  }
+
+  return (
+    <Container>
+      {replacementForEntries.map((t) => (
+        <span key={t.journeyID}>
+          Ersetzt von {t.stop.station.name} bis{' '}
+          {t.stopsReplacing?.station.name ||
+            t.differingDestination?.name ||
+            t.destination.name}{' '}
+          <TransportName transport={t} />
+        </span>
+      ))}
+    </Container>
+  );
+};

--- a/src/client/Common/Components/Details/Stop.tsx
+++ b/src/client/Common/Components/Details/Stop.tsx
@@ -3,6 +3,8 @@ import { CoachSequence } from '../CoachSequence/CoachSequence';
 import { DetailMessages } from '../Messages/Detail';
 import { Messages } from './Messages';
 import { Platform } from '@/client/Common/Components/Platform';
+import { ReplacedBy } from './ReplacedBy';
+import { ReplacementFor } from './ReplacementFor';
 import { Stack, styled } from '@mui/material';
 import { StopPlaceLink } from '@/client/Common/Components/StopPlaceLink';
 import { themeMixins } from '@/client/Themes/mixins';
@@ -81,7 +83,7 @@ const Container = styled('div')<{
     gridTemplateRows: '1fr',
     gridTemplateAreas: `"ar t ${samePlatform ? 'depP' : 'arrP'} c" "dp ${
       hasOccupancy ? 'o' : 't'
-    } depP c" "tw tw tw tw" "wr wr wr wr" "m m m m"`,
+    } depP c" "tw tw tw tw" "rf rf rf rf" "rb rb rb rb" "wr wr wr wr" "m m m m"`,
     alignItems: 'center',
     borderBottom: `1px solid ${theme.vars.palette.text.primary}`,
     position: 'relative',
@@ -192,6 +194,20 @@ export const Stop: FC<Props> = ({
       )}
       <DeparturePlatform {...platforms.departure} />
       {!samePlatform && <ArrivalPlatform {...platforms.arrival} />}
+      <Stack gridArea="rf" paddingLeft={1}>
+        <ReplacementFor
+          stopEva={stop.station.evaNumber}
+          startsReplacing={stop.startsReplacing}
+          stopsReplacing={stop.stopsReplacing}
+        />
+      </Stack>
+      <Stack gridArea="rb" paddingLeft={1}>
+        <ReplacedBy
+          stopEva={stop.station.evaNumber}
+          startsBeingReplacedBy={stop.startsBeingReplacedBy}
+          stopsBeingReplacedBy={stop.stopsBeingReplacedBy}
+        />
+      </Stack>
       <Stack gridArea="tw" paddingLeft={1}>
         <TravelsWith
           stopEva={stop.station.evaNumber}

--- a/src/client/Common/Components/Details/StopList.tsx
+++ b/src/client/Common/Components/Details/StopList.tsx
@@ -1,6 +1,8 @@
 import { css, Stack, styled } from '@mui/material';
 import { Error } from '@mui/icons-material';
 import { Loading } from '../Loading';
+import { ReplacedBySummary } from './ReplacedBySummary';
+import { ReplacementForSummary } from './ReplacementForSummary';
 import { Stop } from '@/client/Common/Components/Details/Stop';
 import { TravelsWithSummary } from '@/client/Common/Components/Details/TravelsWithSummary';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -96,6 +98,8 @@ export const StopList: FC = () => {
   return (
     <Stack>
       <TravelsWithSummary stops={details.stops} />
+      <ReplacementForSummary stops={details.stops} />
+      <ReplacedBySummary stops={details.stops} />
       {detailsStops}
     </Stack>
   );

--- a/src/client/Common/Components/Details/TransportName.tsx
+++ b/src/client/Common/Components/Details/TransportName.tsx
@@ -1,9 +1,14 @@
 import { DetailsLink } from '@/client/Common/Components/Details/DetailsLink';
 import type { FC } from 'react';
-import type { TransportPublicDestinationPortionWorking } from '@/external/generated/risJourneys';
+import type {
+  TransportPublicDestinationOriginJourney,
+  TransportPublicDestinationPortionWorking,
+} from '@/external/generated/risJourneys';
 
 interface Props {
-  transport: TransportPublicDestinationPortionWorking;
+  transport:
+    | TransportPublicDestinationPortionWorking
+    | TransportPublicDestinationOriginJourney;
 }
 
 export const TransportName: FC<Props> = ({ transport }) => {

--- a/src/types/routing.ts
+++ b/src/types/routing.ts
@@ -8,7 +8,10 @@ import type {
 import type { Message } from './iris';
 import type { MinimalStopPlace } from '@/types/stopPlace';
 import type { SecL } from './HAFAS/TripSearch';
-import type { TransportPublicDestinationPortionWorking } from '@/external/generated/risJourneys';
+import type {
+  TransportPublicDestinationOriginJourney,
+  TransportPublicDestinationPortionWorking,
+} from '@/external/generated/risJourneys';
 
 export interface RouteStop {
   arrival?: CommonStopInfo;
@@ -21,6 +24,10 @@ export interface RouteStop {
   irisMessages?: Message[];
   joinsWith?: TransportPublicDestinationPortionWorking[];
   splitsWith?: TransportPublicDestinationPortionWorking[];
+  startsReplacing?: TransportPublicDestinationOriginJourney[];
+  stopsReplacing?: TransportPublicDestinationOriginJourney[];
+  startsBeingReplacedBy?: TransportPublicDestinationOriginJourney[];
+  stopsBeingReplacedBy?: TransportPublicDestinationOriginJourney[];
 }
 export type RouteJourneySegment =
   | RouteJourneySegmentTrain


### PR DESCRIPTION
This pull request adds indicators for when a train is being replaced by another or a train is a replacement for another in the journey details.

This data is similarly sourced, processed and displayed as the travels with feature.

Testing the implementation (especially the frontend) is a bit difficult, it might just not work in the current state.

Here are some testing urls:

A train getting replaced: https://bahn.expert/details/ICE?journeyId=e1422681-3498-3489-8fd5-0c6af14d44e1
Its replacement: https://bahn.expert/details/ICE?journeyId=0b5cf5ff-18e8-3c11-9fa9-37f3d73629a2