### PR TITLE
Update name of Tz 9212 to Fan-Hauptstadt Hamburg

### DIFF
--- a/src/server/coachSequence/TrainNames.ts
+++ b/src/server/coachSequence/TrainNames.ts
@@ -271,6 +271,7 @@ const naming: Record<number, string> = {
   9046: 'Female ICE',
   9050: 'Metropole Ruhr',
   9202: 'Schleswig-Holstein',
+  9212: 'Fan-Hauptstadt Hamburg',
   9237: 'Spree',
   9457: 'Bundesrepublik Deutschland',
   9481: 'Rheinland-Pfalz',


### PR DESCRIPTION
Sources: 
- [DB post on instagram](https://www.instagram.com/p/C6YmuerIkij)
- Tz from `Bahn: Fahrplan & Live Tracking` app:
![image](https://github.com/marudor/bahn.expert/assets/45321107/69825f1e-e191-4184-9a02-7e580e40010b)

