### PR TITLE
Add train names

### DIFF
--- a/src/server/coachSequence/TrainNames.ts
+++ b/src/server/coachSequence/TrainNames.ts
@@ -231,9 +231,13 @@ const naming: Record<number, string> = {
 	2871: 'Leipziger Neuseenland',
 	2874: 'Oberer Neckar',
 	2875: 'Magdeburger Börde',
+	4893: 'Bodetal',
+	4898: 'Lahntal',
 	//
 	// Intercity2 KISS - BR 4110
+	4102: 'Naturpark Schönbuch',
 	4103: 'Allgäu',
+	4108: 'Hegau',
 	4111: 'Gäu',
 	4114: 'Dresden Elbland',
 	4117: 'Mecklenburgische Ostseeküste',
@@ -272,7 +276,9 @@ const naming: Record<number, string> = {
 	9046: 'Female ICE',
 	9050: 'Metropole Ruhr',
 	9202: 'Schleswig-Holstein',
+	9208: 'Nationalpark Bayerischer Wald',
 	9212: 'Fan-Hauptstadt Hamburg',
+	9234: 'Ruhr',
 	9237: 'Spree',
 	9457: 'Bundesrepublik Deutschland',
 	9481: 'Rheinland-Pfalz',


### PR DESCRIPTION
Add train names for
- [4893](https://web.archive.org/web/20230429210924/https://www.deutschebahn.com/de/presse/presse-regional/pr-leipzig-de/aktuell/presseinformationen/Grosser-Bahnhof-in-der-Landeshauptstadt-Magdeburg-feiert-doppelte-Zugtaufe-10580402) (IC2 Twindexx 2. Abruf)
- [4898](https://web.archive.org/web/20221020230540/https://www.deutschebahn.com/pr-frankfurt-de/Zugtaufe-mit-Goethe-in-Wetzlar-Intercity-erhaelt-den-Namen-Lahntal--9081688) (IC2 Twindexx 3. Abruf)
- [4102](https://web.archive.org/web/20221114160124/https://www.deutschebahn.com/pr-stuttgart-de/aktuell/presseinformationen/164-pm_ic_zugtaufe_naturpark_schoenbuch-9172736) (IC2 KISS)
- [4108](https://www.deutschebahn.com/de/presse/presse-regional/pr-stuttgart-de/aktuell/presseinformationen/-Hegau-Moderner-Intercity-2-rollt-als-neuer-Botschafter-ueber-die-Gaeubahn-12848372) (IC2 KISS)
- [9208](https://www.deutschebahn.com/de/presse/presse-regional/pr-muenchen-de/aktuell/presseinformationen/Gruen-und-Gruen-gesellt-sich-gern-ICE-4-auf-den-Namen-Nationalpark-Bayerischer-Wald-getauft-12855920) (ICE 4)
- [9234](https://www.deutschebahn.com/de/presse/presse-regional/pr-duesseldorf-de/presseinformationen-regional/Gewinnspiel-zur-EM-Neuer-ICE-heisst-Ruhr--12916106) (ICE 4)